### PR TITLE
Update tomcat baseimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ FROM tomcat:8.5.53-jdk11-openjdk-slim
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
-		libvoikko1 \
-		voikko-fi \
+		libvoikko1=4.2-1 \
+		voikko-fi=2.2-1.1 \
 		gosu \
 	&& rm -rf /var/lib/apt/lists/* /usr/include/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY pom.xml .
 RUN mvn package
 
 
-FROM tomcat:8-jdk11-slim
+FROM tomcat:8.5.53-jdk11-openjdk-slim
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Use a more recent Tomcat (8.5.53) and pin it. Also pin Voikko libraries versions to prevent confusion in future (when Voikko version changes, suggestion results can change).